### PR TITLE
Add test instance for local development

### DIFF
--- a/src/instances/test.yaml
+++ b/src/instances/test.yaml
@@ -1,0 +1,13 @@
+---
+id: test
+name: >-
+    *datalab* test instances
+contact:
+    - name: datalab development team
+      email: dev@datalab-org.io
+canonical_url: http://localhost:8080
+api_url: http://localhost:5000
+description: >-
+    This *datalab* federation entry point is used for testing purposes.
+    It QR codes from local developments to be tested with the link resolver.
+status: staging


### PR DESCRIPTION
This PR adds the `test` instance to the datalab federation, which should allow developers to test redirect behaviour to localhost. It uses the `status: staging` to indicate that data should not be aggregated from this deployment.